### PR TITLE
Optimize single literals

### DIFF
--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -1,4 +1,4 @@
-import { FindDiscriminator, IsDiscriminableUnion, IsLiteralUnion } from "./unions";
+import { FindDiscriminator, IsDiscriminableUnion, IsLiteralUnion, type IsUnion } from "./unions";
 import { HasRest, RestType, SplitRest } from "./tuples";
 
 type IsNumber<T, K extends string> = `_${K}` extends keyof T ? true : false;
@@ -21,7 +21,7 @@ type ArrayMetadata<T extends unknown[]> = [T] extends [{ length: number }]
  * This can be used in your own user macros to generate serializers for arbitrary types, such as for a networking library.
  */
 export type SerializerMetadata<T> = IsLiteralUnion<T> extends true
-	? ["literal", NonNullable<T>[]]
+	? ["literal", NonNullable<T>[], true extends IsUnion<T> ? false : true]
 	: unknown extends T
 	? ["optional", ["blob"]]
 	: undefined extends T
@@ -101,5 +101,5 @@ export type SerializerData =
 	| ["map", SerializerData, SerializerData]
 	| ["set", SerializerData]
 	| ["optional", SerializerData]
-	| ["literal", defined[]]
+	| ["literal", defined[], boolean]
 	| ["blob"];

--- a/src/metadata/unions.ts
+++ b/src/metadata/unions.ts
@@ -1,4 +1,3 @@
-type IsUnion<T, U = T> = T extends T ? (U extends T ? never : true) : never;
 type FilterNever<T> = { [k in { [k in keyof T]: T[k] extends never ? never : k }[keyof T]]: T[k] };
 
 type IsLiteral<T> = T extends undefined
@@ -15,6 +14,8 @@ type IsLiteral<T> = T extends undefined
 	? true
 	: false;
 
+export type IsUnion<T, U = T> = T extends T ? (U extends T ? never : true) : never;
+
 export type FindDiscriminator<T> = keyof T &
 	keyof (T extends T
 		? FilterNever<{ [k in keyof T]: T[k] extends string ? (string extends T[k] ? never : k) : never }>
@@ -27,7 +28,7 @@ export type IsDiscriminableUnion<T> = true extends IsUnion<T>
 	: false;
 
 // This doesn't check whether T is a union, only that it is comprised of only literal values.
-// The distinction isn't very important for serialization purposes, as we can still optimize a single literal.
+// The literal metadata will check for non-unions itself to optimize single literal values into zero bytes.
 // We also exclude plain `boolean` here as that has a more efficient special case.
 export type IsLiteralUnion<T> = [boolean, NonNullable<T>] extends [NonNullable<T>, boolean]
 	? false

--- a/src/serialization/createDeserializer.ts
+++ b/src/serialization/createDeserializer.ts
@@ -130,8 +130,14 @@ export function createDeserializer<T>(meta: SerializerData) {
 
 			return object;
 		} else if (kind === "literal") {
-			offset += 1;
-			return meta[1][buffer.readu8(buf, currentOffset)];
+			const literals = meta[1];
+			const isSingleLiteral = meta[2];
+			if (isSingleLiteral) {
+				return literals[0];
+			} else {
+				offset += 1;
+				return literals[buffer.readu8(buf, currentOffset)];
+			}
 		} else if (kind === "blob") {
 			blobIndex++;
 			return blobs![blobIndex - 1];

--- a/src/serialization/createSerializer.ts
+++ b/src/serialization/createSerializer.ts
@@ -147,12 +147,15 @@ export function createSerializer<T>(meta: SerializerData) {
 			serialize(value, tagged[tagIndex][1]);
 		} else if (kind === "literal") {
 			const literals = meta[1];
-			const index = literals.indexOf(value as defined);
-			allocate(1);
+			const isSingleLiteral = meta[2];
+			if (!isSingleLiteral) {
+				const index = literals.indexOf(value as defined);
+				allocate(1);
 
-			// We support `undefined` as a literal, but `indexOf` will actually return -1
-			// This is fine, though, as -1 will serialize as 255 which is guarantee to be undefined with the 8 bit size limit.
-			buffer.writeu8(buf, currentOffset, index);
+				// We support `undefined` as a literal, but `indexOf` will actually return -1
+				// This is fine, though, as -1 will serialize as 255 which is guarantee to be undefined with the 8 bit size limit.
+				buffer.writeu8(buf, currentOffset, index);
+			}
 		} else if (kind === "blob") {
 			// Value will always be defined because if it isn't, it will be wrapped in `optional`
 			blobs.push(value!);


### PR DESCRIPTION
Optimizes single literal type into zero bytes. I decided this case wasn't worth a special code path and so it is handled by the `literal` metadata.