### PR TITLE
Support larger unions

### DIFF
--- a/src/createBinarySerializer.ts
+++ b/src/createBinarySerializer.ts
@@ -68,6 +68,12 @@ function optimizeSerializerData(data: SerializerData): SerializerData {
 		data = [data[0], optimizeSerializerData(data[1]), optimizeSerializerData(data[2])];
 	} else if (data[0] === "tuple") {
 		data = [data[0], data[1].map(optimizeSerializerData), data[2] ? optimizeSerializerData(data[2]) : undefined];
+	} else if (data[0] === "literal") {
+		// Since `undefined` is not included in the size of `data[1]`,
+		// we add the existing value of `data[3]` (which is 1 if undefined is in the union) to `data[1]`
+		// to determine the final required size.
+		// A size of -1 means this isn't a union.
+		data = [data[0], data[1], data[2] === -1 ? 0 : data[2] + data[1].size() <= 256 ? 1 : 2];
 	}
 
 	return data;

--- a/src/createBinarySerializer.ts
+++ b/src/createBinarySerializer.ts
@@ -62,6 +62,7 @@ function optimizeSerializerData(data: SerializerData): SerializerData {
 			data[0],
 			data[1],
 			data[2].map(([key, data]): [unknown, SerializerData] => [key, optimizeSerializerData(data)]),
+			data[2].size() <= 256 ? 1 : 2,
 		];
 	} else if (data[0] === "map") {
 		data = [data[0], optimizeSerializerData(data[1]), optimizeSerializerData(data[2])];

--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -21,7 +21,7 @@ type ArrayMetadata<T extends unknown[]> = [T] extends [{ length: number }]
  * This can be used in your own user macros to generate serializers for arbitrary types, such as for a networking library.
  */
 export type SerializerMetadata<T> = IsLiteralUnion<T> extends true
-	? ["literal", NonNullable<T>[], true extends IsUnion<T> ? false : true]
+	? ["literal", NonNullable<T>[], true extends IsUnion<T> ? (undefined extends T ? 1 : 0) : -1]
 	: unknown extends T
 	? ["optional", ["blob"]]
 	: undefined extends T
@@ -103,5 +103,5 @@ export type SerializerData =
 	| ["map", SerializerData, SerializerData]
 	| ["set", SerializerData]
 	| ["optional", SerializerData]
-	| ["literal", defined[], boolean]
+	| ["literal", defined[], number]
 	| ["blob"];

--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -63,6 +63,8 @@ export type SerializerMetadata<T> = IsLiteralUnion<T> extends true
 			FindDiscriminator<T> extends infer D
 				? (T extends T ? [T[D & keyof T], SerializerMetadata<Omit<T, D & keyof T>>] : never)[]
 				: never,
+			// This is the byte size length. This is annoying (and slow) to calculate in TS, so it's done at runtime.
+			-1,
 	  ]
 	: true extends HasNominal<keyof T>
 	? ["blob"]
@@ -95,7 +97,7 @@ export type SerializerData =
 	| ["vector"]
 	| ["object", Array<string | SerializerData>, object]
 	| ["object_raw", [string, SerializerData][]]
-	| ["union", string, [unknown, SerializerData][]]
+	| ["union", string, [unknown, SerializerData][], number]
 	| ["array", SerializerData]
 	| ["tuple", SerializerData[], SerializerData | undefined]
 	| ["map", SerializerData, SerializerData]

--- a/src/serialization/createDeserializer.ts
+++ b/src/serialization/createDeserializer.ts
@@ -121,9 +121,10 @@ export function createDeserializer<T>(meta: SerializerData) {
 			offset += 1;
 			return buffer.readu8(buf, currentOffset) === 1 ? deserialize(meta[1]) : undefined;
 		} else if (kind === "union") {
-			offset += 1;
+			const byteSize = meta[3];
+			const tagIndex = byteSize === 1 ? buffer.readu8(buf, currentOffset) : buffer.readu16(buf, currentOffset);
+			offset += byteSize;
 
-			const tagIndex = buffer.readu8(buf, currentOffset);
 			const tag = meta[2][tagIndex];
 			const object = deserialize(tag[1]);
 			(object as Record<string, unknown>)[meta[1]] = tag[0];

--- a/src/serialization/createDeserializer.ts
+++ b/src/serialization/createDeserializer.ts
@@ -132,12 +132,15 @@ export function createDeserializer<T>(meta: SerializerData) {
 			return object;
 		} else if (kind === "literal") {
 			const literals = meta[1];
-			const isSingleLiteral = meta[2];
-			if (isSingleLiteral) {
-				return literals[0];
-			} else {
+			const byteSize = meta[2];
+			if (byteSize === 1) {
 				offset += 1;
 				return literals[buffer.readu8(buf, currentOffset)];
+			} else if (byteSize === 2) {
+				offset += 2;
+				return literals[buffer.readu16(buf, currentOffset)];
+			} else {
+				return literals[0];
 			}
 		} else if (kind === "blob") {
 			blobIndex++;


### PR DESCRIPTION
Adds support for unions up to 2^16.

TypeScript unions have a cap of 100,000 constituents (the soft limit is much lower) and 16 bit supports up to 65,536 constituents.