### PR TITLE
Add packed structs

### DIFF
--- a/src/createBinarySerializer.ts
+++ b/src/createBinarySerializer.ts
@@ -74,6 +74,8 @@ function optimizeSerializerData(data: SerializerData): SerializerData {
 		// to determine the final required size.
 		// A size of -1 means this isn't a union.
 		data = [data[0], data[1], data[2] === -1 ? 0 : data[2] + data[1].size() <= 256 ? 1 : 2];
+	} else if (data[0] === "packed") {
+		data = [data[0], data[1], optimizeSerializerData(data[2]), math.ceil(data[1].size() / 8)];
 	}
 
 	return data;

--- a/src/dataType.ts
+++ b/src/dataType.ts
@@ -12,4 +12,6 @@ export namespace DataType {
 	export type i8 = number & { _i8?: never };
 	export type i16 = number & { _i16?: never };
 	export type i32 = number & { _i32?: never };
+
+	export type Packed = { _packed?: never };
 }

--- a/src/metadata/bitfields.ts
+++ b/src/metadata/bitfields.ts
@@ -1,0 +1,7 @@
+import type { DataType } from "../dataType";
+
+// We only support packing booleans in packed structs at the moment.
+export type ExtractBitFields<T> = ExtractMembers<T, boolean>;
+export type ExcludeBitFields<T> = ExcludeMembers<T, boolean>;
+
+export type RawType<T> = Omit<T, keyof DataType.Packed & keyof T>;

--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -1,5 +1,6 @@
 import { FindDiscriminator, IsDiscriminableUnion, IsLiteralUnion, type IsUnion } from "./unions";
 import { HasRest, RestType, SplitRest } from "./tuples";
+import type { ExcludeBitFields, ExtractBitFields, RawType } from "./bitfields";
 
 type IsNumber<T, K extends string> = `_${K}` extends keyof T ? true : false;
 type HasNominal<T> = T extends T ? (T extends `_nominal_${string}` ? true : never) : never;
@@ -68,6 +69,8 @@ export type SerializerMetadata<T> = IsLiteralUnion<T> extends true
 	  ]
 	: true extends HasNominal<keyof T>
 	? ["blob"]
+	: "_packed" extends keyof T
+	? ["packed", (keyof ExtractBitFields<T> & string)[], SerializerMetadata<ExcludeBitFields<RawType<T>>>, -1]
 	: T extends object
 	? [
 			"object_raw",
@@ -97,6 +100,7 @@ export type SerializerData =
 	| ["vector"]
 	| ["object", Array<string | SerializerData>, object]
 	| ["object_raw", [string, SerializerData][]]
+	| ["packed", string[], SerializerData, number]
 	| ["union", string, [unknown, SerializerData][], number]
 	| ["array", SerializerData]
 	| ["tuple", SerializerData[], SerializerData | undefined]


### PR DESCRIPTION
Packed structs will bit pack all boolean fields in a single (or more) byte.

This may be extended in the future to support other binary values (such as a literal union with two constituents)