### PR TITLE
Fix bitfields when optional fields are present

### DIFF
--- a/src/metadata/bitfields.ts
+++ b/src/metadata/bitfields.ts
@@ -1,7 +1,8 @@
 import type { DataType } from "../dataType";
 
 // We only support packing booleans in packed structs at the moment.
-export type ExtractBitFields<T> = ExtractMembers<T, boolean>;
-export type ExcludeBitFields<T> = ExcludeMembers<T, boolean>;
+// We cannot use ExtractMembers and ExcludeMembers as they can leak `undefined`
+export type ExtractBitFields<T> = Pick<T, ExtractKeys<T, boolean> & keyof T>;
+export type ExcludeBitFields<T> = Omit<T, ExtractKeys<T, boolean> & keyof T>;
 
 export type RawType<T> = Omit<T, keyof DataType.Packed & keyof T>;


### PR DESCRIPTION
TypeScript will leak `undefined` into the keys of objects under certain circumstances and this accounts for that in the bitfield types

This does not account for an already broken object being passed into the types, it only prevents the serializer's types from causing the breakage.