### PR TITLE
Add improved bitpacking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
 		"plugin:prettier/recommended"
 	],
 	"rules": {
-		"prettier/prettier": "warn"
+		"prettier/prettier": "warn",
+		"no-constant-condition": "off"
 	}
 }

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ export interface Data {
 	map: Map<Instance, boolean>;
 	set: Set<{ type: "string"; value: string } | { type: "number"; value: number }>;
 
-	packed: PackedObject;
+	packed: DataType.Packed<PackedObject>;
 }
 
-// This interface will take up 2 bytes.
-// 1 byte for the i8, and 1 byte for 8 booleans.
-// Without packing, this interface would take 9 bytes.
-interface PackedObject extends DataType.Packed {
+// This interface will take up a byte and 8-10 bits.
+// 1 byte for the i8, 8 bits (1 byte) for 8 booleans, and 1-2 bits for the optional field.
+// Without packing, this interface would take up to 11 bytes.
+//
+// Packing also optimizes `optional` values by using a single bit for the presence of the value.
+// Packing recursively applies to the entire object, including things like arrays, other objects, etc.
+interface PackedObject {
 	num: DataType.i8;
 	a: boolean;
 	b: boolean;
@@ -70,6 +73,9 @@ interface PackedObject extends DataType.Packed {
 	f: boolean;
 	g: boolean;
 	h: boolean;
+
+	// This only takes up to 2 bits to encode in a packed type!
+	i?: boolean;
 }
 
 const testData: Data = {

--- a/src/createBinarySerializer.ts
+++ b/src/createBinarySerializer.ts
@@ -1,7 +1,8 @@
 import { Modding } from "@flamework/core";
-import type { SerializerData, SerializerMetadata } from "./metadata";
+import type { SerializerMetadata } from "./metadata";
 import { createSerializer } from "./serialization/createSerializer";
 import { createDeserializer } from "./serialization/createDeserializer";
+import { processSerializerData } from "./processSerializerData";
 
 /**
  * A binary serializer.
@@ -36,47 +37,9 @@ export interface Serializer<T> {
  * @metadata macro
  */
 export function createBinarySerializer<T>(meta?: Modding.Many<SerializerMetadata<T>>): Serializer<T> {
-	const optimized = optimizeSerializerData(meta as never);
+	const processed = processSerializerData(meta as never);
 	return {
-		serialize: createSerializer(optimized),
-		deserialize: createDeserializer(optimized),
+		serialize: createSerializer(processed),
+		deserialize: createDeserializer(processed),
 	};
-}
-
-function optimizeSerializerData(data: SerializerData): SerializerData {
-	if (data[0] === "object_raw") {
-		// We transform objects as an array of tuples, but this is slow to iterate over.
-		// We flatten the raw generated metadata into a single array, which can be iterated much quicker.
-		// We also create a preallocated object that we can clone as we already know the structure ahead of time.
-		const preallocation = new Set<string>();
-		const transformed = new Array<string | SerializerData>();
-		for (const [key, meta] of data[1]) {
-			transformed.push(key, optimizeSerializerData(meta));
-			preallocation.add(key);
-		}
-		data = ["object", transformed, preallocation];
-	} else if (data[0] === "array" || data[0] === "optional" || data[0] === "set") {
-		data = [data[0], optimizeSerializerData(data[1])];
-	} else if (data[0] === "union") {
-		data = [
-			data[0],
-			data[1],
-			data[2].map(([key, data]): [unknown, SerializerData] => [key, optimizeSerializerData(data)]),
-			data[2].size() <= 256 ? 1 : 2,
-		];
-	} else if (data[0] === "map") {
-		data = [data[0], optimizeSerializerData(data[1]), optimizeSerializerData(data[2])];
-	} else if (data[0] === "tuple") {
-		data = [data[0], data[1].map(optimizeSerializerData), data[2] ? optimizeSerializerData(data[2]) : undefined];
-	} else if (data[0] === "literal") {
-		// Since `undefined` is not included in the size of `data[1]`,
-		// we add the existing value of `data[3]` (which is 1 if undefined is in the union) to `data[1]`
-		// to determine the final required size.
-		// A size of -1 means this isn't a union.
-		data = [data[0], data[1], data[2] === -1 ? 0 : data[2] + data[1].size() <= 256 ? 1 : 2];
-	} else if (data[0] === "packed") {
-		data = [data[0], data[1], optimizeSerializerData(data[2]), math.ceil(data[1].size() / 8)];
-	}
-
-	return data;
 }

--- a/src/dataType.ts
+++ b/src/dataType.ts
@@ -13,5 +13,5 @@ export namespace DataType {
 	export type i16 = number & { _i16?: never };
 	export type i32 = number & { _i32?: never };
 
-	export type Packed = { _packed?: never };
+	export type Packed<T> = T & { _packed?: [T] };
 }

--- a/src/metadata/bitfields.ts
+++ b/src/metadata/bitfields.ts
@@ -1,8 +1,0 @@
-import type { DataType } from "../dataType";
-
-// We only support packing booleans in packed structs at the moment.
-// We cannot use ExtractMembers and ExcludeMembers as they can leak `undefined`
-export type ExtractBitFields<T> = Pick<T, ExtractKeys<T, boolean> & keyof T>;
-export type ExcludeBitFields<T> = Omit<T, ExtractKeys<T, boolean> & keyof T>;
-
-export type RawType<T> = Omit<T, keyof DataType.Packed & keyof T>;

--- a/src/processSerializerData.ts
+++ b/src/processSerializerData.ts
@@ -1,0 +1,114 @@
+import type { SerializerData } from "./metadata";
+
+const enum IterationFlags {
+	Default = 0,
+	SizeUnknown = 1 << 0,
+	Packed = 1 << 1,
+}
+
+export interface ProcessedInfo {
+	flags: IterationFlags;
+	containsPacking: boolean;
+	packingBits: number | undefined;
+}
+
+export interface ProcessedSerializerData extends ProcessedInfo {
+	data: SerializerData;
+}
+
+function addPackedBit(info: ProcessedInfo) {
+	if ((info.flags & IterationFlags.Packed) !== 0 && info.packingBits !== undefined) {
+		if ((info.flags & IterationFlags.SizeUnknown) !== 0) {
+			info.packingBits = undefined;
+		} else {
+			info.packingBits += 1;
+		}
+	}
+}
+
+/**
+ * This runs an additional pass over the SerializerData to perform calculations not feasible type-wise:
+ * 1. Optimize objects
+ * 2. Calculate union sizes
+ * 3. Calculate packing
+ */
+function iterateSerializerData(data: SerializerData, info: ProcessedInfo): SerializerData {
+	const flags = info.flags;
+	const kind = data[0];
+
+	if (kind === "object_raw") {
+		// We transform objects as an array of tuples, but this is slow to iterate over.
+		// We flatten the raw generated metadata into a single array, which can be iterated much quicker.
+		// We also create a preallocated object that we can clone as we already know the structure ahead of time.
+		const preallocation = new Set<string>();
+		const transformed = new Array<string | SerializerData>();
+		for (const [key, meta] of data[1]) {
+			transformed.push(key, iterateSerializerData(meta, info));
+			preallocation.add(key);
+		}
+
+		data = ["object", transformed, preallocation];
+	} else if (kind === "optional") {
+		info.flags |= IterationFlags.SizeUnknown;
+		addPackedBit(info);
+
+		data = [kind, iterateSerializerData(data[1], info)];
+	} else if (kind === "array" || kind === "set") {
+		info.flags |= IterationFlags.SizeUnknown;
+
+		data = [kind, iterateSerializerData(data[1], info)];
+	} else if (kind === "union") {
+		info.flags |= IterationFlags.SizeUnknown;
+
+		data = [
+			kind,
+			data[1],
+			data[2].map(([key, data]): [unknown, SerializerData] => [key, iterateSerializerData(data, info)]),
+			data[2].size() <= 256 ? 1 : 2,
+		];
+	} else if (kind === "map") {
+		info.flags |= IterationFlags.SizeUnknown;
+
+		data = [kind, iterateSerializerData(data[1], info), iterateSerializerData(data[2], info)];
+	} else if (kind === "tuple") {
+		const fixedElements = data[1].map((v) => iterateSerializerData(v, info));
+
+		let restElement;
+		if (data[2] !== undefined) {
+			info.flags |= IterationFlags.SizeUnknown;
+
+			restElement = iterateSerializerData(data[2], info);
+		}
+
+		data = [kind, fixedElements, restElement];
+	} else if (kind === "literal") {
+		// Since `undefined` is not included in the size of `data[1]`,
+		// we add the existing value of `data[3]` (which is 1 if undefined is in the union) to `data[1]`
+		// to determine the final required size.
+		// A size of -1 means this isn't a union.
+		data = [kind, data[1], data[2] === -1 ? 0 : data[2] + data[1].size() <= 256 ? 1 : 2];
+	} else if (kind === "packed") {
+		info.flags |= IterationFlags.Packed;
+		info.containsPacking = true;
+
+		data = [kind, iterateSerializerData(data[1], info)];
+	} else if (kind === "boolean") {
+		addPackedBit(info);
+	}
+
+	info.flags = flags;
+
+	return data;
+}
+
+export function processSerializerData(rawData: SerializerData): ProcessedSerializerData {
+	const processedInfo: ProcessedSerializerData = {
+		data: rawData,
+		flags: IterationFlags.Default,
+		containsPacking: false,
+		packingBits: 0,
+	};
+
+	processedInfo.data = iterateSerializerData(rawData, processedInfo);
+	return processedInfo;
+}

--- a/src/processSerializerData.ts
+++ b/src/processSerializerData.ts
@@ -9,7 +9,8 @@ const enum IterationFlags {
 export interface ProcessedInfo {
 	flags: IterationFlags;
 	containsPacking: boolean;
-	packingBits: number | undefined;
+	containsUnknownPacking: boolean;
+	packingBits: number;
 }
 
 export interface ProcessedSerializerData extends ProcessedInfo {
@@ -17,10 +18,11 @@ export interface ProcessedSerializerData extends ProcessedInfo {
 }
 
 function addPackedBit(info: ProcessedInfo) {
-	if ((info.flags & IterationFlags.Packed) !== 0 && info.packingBits !== undefined) {
+	if ((info.flags & IterationFlags.Packed) !== 0) {
 		if ((info.flags & IterationFlags.SizeUnknown) !== 0) {
-			info.packingBits = undefined;
+			info.containsUnknownPacking = true;
 		} else {
+			// We only keep track of guaranteed packing bits, which we can use for optimization.
 			info.packingBits += 1;
 		}
 	}
@@ -106,6 +108,7 @@ export function processSerializerData(rawData: SerializerData): ProcessedSeriali
 		data: rawData,
 		flags: IterationFlags.Default,
 		containsPacking: false,
+		containsUnknownPacking: false,
 		packingBits: 0,
 	};
 

--- a/src/processSerializerData.ts
+++ b/src/processSerializerData.ts
@@ -20,6 +20,8 @@ export interface ProcessedSerializerData extends ProcessedInfo {
 
 function addPackedBit(info: ProcessedInfo) {
 	if ((info.flags & IterationFlags.Packed) !== 0) {
+		info.containsPacking = true;
+
 		if ((info.flags & IterationFlags.SizeUnknown) !== 0) {
 			info.containsUnknownPacking = true;
 		} else {
@@ -92,7 +94,6 @@ function iterateSerializerData(data: SerializerData, info: ProcessedInfo): Seria
 		data = [kind, data[1], data[2] === -1 ? 0 : data[2] + data[1].size() <= 256 ? 1 : 2];
 	} else if (kind === "packed") {
 		info.flags |= IterationFlags.Packed;
-		info.containsPacking = true;
 
 		data = [kind, iterateSerializerData(data[1], info)];
 	} else if (kind === "boolean") {

--- a/src/serialization/createDeserializer.ts
+++ b/src/serialization/createDeserializer.ts
@@ -235,16 +235,16 @@ export function createDeserializer<T>(info: ProcessedSerializerData) {
 
 		if (info.containsPacking) {
 			let byteCount;
-			if (info.packingBits !== undefined) {
-				byteCount = math.ceil(info.packingBits / 8);
-			} else {
+			if (info.containsUnknownPacking) {
 				byteCount = buffer.readu8(buf, 0);
 				offset++;
+			} else {
+				byteCount = math.ceil(info.packingBits / 8);
 			}
 
 			bits = table.create(byteCount * 8);
 
-			for (const _ of $range(0, byteCount - 1)) {
+			for (const _ of $range(1, byteCount)) {
 				const currentByte = buffer.readu8(buf, offset);
 
 				for (const bit of $range(0, 7)) {


### PR DESCRIPTION
BREAKING: `DataType.Packed` no longer supports intersections, and must be used like `DataType.Packed<T>`

The `Packed` type will now apply recursively to all types below it. This also lifts the restriction of packed types being limited to object types, and they can now be placed on any type (including tuples, booleans, etc)

Internally, the `Packed` type now allocates an array of booleans which can be arbitrarily sized or fixed size. In the case of arbitrarily sized boolean arrays, a byte will be allocated in the buffer indicating the length.

This array of booleans is always embedded at the start of the serialized buffer, which also means separately packed types will share the same space.

Optional fields now also optimize the presence boolean into a single bit.